### PR TITLE
linux-libc-headers: upgrade to v4.20

### DIFF
--- a/recipes-kernel/linux-libc-headers/linux-libc-headers_4.20.bb
+++ b/recipes-kernel/linux-libc-headers/linux-libc-headers_4.20.bb
@@ -9,4 +9,5 @@ SRC_URI_append_libc-musl = "\
     file://0001-include-linux-stddef.h-in-swab.h-uapi-header.patch \
    "
 
-SRC_URI[md5sum] = "2ea08d2983ce6dee980ecebc5baf2c0d"
+SRC_URI[md5sum] = "d39dd4ba2d5861c54b90d49be19eaf31"
+

--- a/recipes-multimedia/libva-v4l2-request/files/0001-Add-missing-defines-to-fix-build-with-v4.20.patch
+++ b/recipes-multimedia/libva-v4l2-request/files/0001-Add-missing-defines-to-fix-build-with-v4.20.patch
@@ -1,0 +1,118 @@
+From 2f34a3de09cae7b32a050738d3a63367328be0ce Mon Sep 17 00:00:00 2001
+From: Roman Stratiienko <roman.stratiienko@globallogic.com>
+Date: Tue, 8 Jan 2019 14:33:42 +0200
+Subject: [PATCH] Add missing defines to fix build with v4.20
+
+---
+ include/mpeg2-ctrls.h | 86 +++++++++++++++++++++++++++++++++++++++++++
+ src/mpeg2.c           |  1 +
+ 2 files changed, 87 insertions(+)
+ create mode 100644 include/mpeg2-ctrls.h
+
+diff --git a/include/mpeg2-ctrls.h b/include/mpeg2-ctrls.h
+new file mode 100644
+index 0000000..d21f40e
+--- /dev/null
++++ b/include/mpeg2-ctrls.h
+@@ -0,0 +1,86 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * These are the MPEG2 state controls for use with stateless MPEG-2
++ * codec drivers.
++ *
++ * It turns out that these structs are not stable yet and will undergo
++ * more changes. So keep them private until they are stable and ready to
++ * become part of the official public API.
++ */
++
++#ifndef _MPEG2_CTRLS_H_
++#define _MPEG2_CTRLS_H_
++
++#define V4L2_CID_MPEG_VIDEO_MPEG2_SLICE_PARAMS		(V4L2_CID_MPEG_BASE+250)
++#define V4L2_CID_MPEG_VIDEO_MPEG2_QUANTIZATION		(V4L2_CID_MPEG_BASE+251)
++
++/* enum v4l2_ctrl_type type values */
++#define V4L2_CTRL_TYPE_MPEG2_SLICE_PARAMS 0x0103
++#define	V4L2_CTRL_TYPE_MPEG2_QUANTIZATION 0x0104
++
++#define V4L2_MPEG2_PICTURE_CODING_TYPE_I	1
++#define V4L2_MPEG2_PICTURE_CODING_TYPE_P	2
++#define V4L2_MPEG2_PICTURE_CODING_TYPE_B	3
++#define V4L2_MPEG2_PICTURE_CODING_TYPE_D	4
++
++struct v4l2_mpeg2_sequence {
++	/* ISO/IEC 13818-2, ITU-T Rec. H.262: Sequence header */
++	__u16	horizontal_size;
++	__u16	vertical_size;
++	__u32	vbv_buffer_size;
++
++	/* ISO/IEC 13818-2, ITU-T Rec. H.262: Sequence extension */
++	__u8	profile_and_level_indication;
++	__u8	progressive_sequence;
++	__u8	chroma_format;
++	__u8	pad;
++};
++
++struct v4l2_mpeg2_picture {
++	/* ISO/IEC 13818-2, ITU-T Rec. H.262: Picture header */
++	__u8	picture_coding_type;
++
++	/* ISO/IEC 13818-2, ITU-T Rec. H.262: Picture coding extension */
++	__u8	f_code[2][2];
++	__u8	intra_dc_precision;
++	__u8	picture_structure;
++	__u8	top_field_first;
++	__u8	frame_pred_frame_dct;
++	__u8	concealment_motion_vectors;
++	__u8	q_scale_type;
++	__u8	intra_vlc_format;
++	__u8	alternate_scan;
++	__u8	repeat_first_field;
++	__u8	progressive_frame;
++	__u8	pad;
++};
++
++struct v4l2_ctrl_mpeg2_slice_params {
++	__u32	bit_size;
++	__u32	data_bit_offset;
++
++	struct v4l2_mpeg2_sequence sequence;
++	struct v4l2_mpeg2_picture picture;
++
++	/* ISO/IEC 13818-2, ITU-T Rec. H.262: Slice */
++	__u8	quantiser_scale_code;
++
++	__u8	backward_ref_index;
++	__u8	forward_ref_index;
++	__u8	pad;
++};
++
++struct v4l2_ctrl_mpeg2_quantization {
++	/* ISO/IEC 13818-2, ITU-T Rec. H.262: Quant matrix extension */
++	__u8	load_intra_quantiser_matrix;
++	__u8	load_non_intra_quantiser_matrix;
++	__u8	load_chroma_intra_quantiser_matrix;
++	__u8	load_chroma_non_intra_quantiser_matrix;
++
++	__u8	intra_quantiser_matrix[64];
++	__u8	non_intra_quantiser_matrix[64];
++	__u8	chroma_intra_quantiser_matrix[64];
++	__u8	chroma_non_intra_quantiser_matrix[64];
++};
++
++#endif
+diff --git a/src/mpeg2.c b/src/mpeg2.c
+index eebeb33..883e0fe 100644
+--- a/src/mpeg2.c
++++ b/src/mpeg2.c
+@@ -37,6 +37,7 @@
+ #include <linux/videodev2.h>
+ 
+ #include "v4l2.h"
++#include "../include/mpeg2-ctrls.h"
+ 
+ int mpeg2_set_controls(struct request_data *driver_data,
+ 		       struct object_context *context_object,
+-- 
+2.17.1
+

--- a/recipes-multimedia/libva-v4l2-request/libva-v4l2-request_git.bb
+++ b/recipes-multimedia/libva-v4l2-request/libva-v4l2-request_git.bb
@@ -16,6 +16,7 @@ SRCREV = "85a0f72f72d22d83e300efecd028482bea14ceee"
 
 SRC_URI = "git://github.com/bootlin/libva-v4l2-request.git;branch=master \
 	file://0001-Replace-bootlin-libdrm-sun4i-dependency-with-intel-l.patch \
+	file://0001-Add-missing-defines-to-fix-build-with-v4.20.patch \
 	file://libva-v4l2-request-env.sh \
 	"
 


### PR DESCRIPTION
libva-v4l2-request build error due to missing mpeg2 definitions is fixed

